### PR TITLE
Makes the loader resolution more tolerant

### DIFF
--- a/utils/resolve.js
+++ b/utils/resolve.js
@@ -33,7 +33,11 @@ function tryRequire(target, sourceFile) {
   try {
     // Check if the target exists
     if (sourceFile != null) {
-      resolved = createRequireFromPath(sourceFile).resolve(target)
+      try {
+        resolved = createRequireFromPath(sourceFile).resolve(target)
+      } catch {
+        resolved = require.resolve(target)
+      }
     } else {
       resolved = require.resolve(target)
     }


### PR DESCRIPTION
Assuming that the repro provided by https://github.com/benmosher/eslint-plugin-import/issues/1604#issuecomment-573365506 will be valid, maybe a simple solution would be to be too laxist for now and just fallback to the hoisting resolution if the file-relative one doesn't find the loader.

And then the next time `eslint-import-utils` receives a major bump, revert the `try/catch` block and go back to using exclusively `createRequire`.

cc @ljharb